### PR TITLE
Execute 'normal' without mapping

### DIFF
--- a/autoload/auto_origami.vim
+++ b/autoload/auto_origami.vim
@@ -43,11 +43,11 @@ function! s:HasFolds()
     " Move to the end of the current fold and check again in case the
     " cursor was on the sole fold in the file when we checked
     if line('.')!=1
-      normal [z
-      normal k
+      normal! [z
+      normal! k
     else
-      normal ]z
-      normal j
+      normal! ]z
+      normal! j
     endif
     let l:foldsexist=s:HasFoldsInner()
     if l:foldsexist
@@ -65,9 +65,9 @@ function! s:HasFoldsInner()
     return 1
   endif
   let l:origline=line('.')
-  normal zk
+  normal! zk
   if l:origline==line('.')
-    normal zj
+    normal! zj
     if l:origline==line('.')
       return 0
     else

--- a/doc/auto-origami.txt
+++ b/doc/auto-origami.txt
@@ -113,6 +113,9 @@ See the code for style guidelines.
 ==============================================================================
 CHANGELOG                                           *auto-origami-changelog*
 
+*v1.1.6*                                                      21 May 2020
+  * Use `:normal!` to avoid issues with mappings.
+
 *v1.1.5*                                                      25 July 2019
   * Make AutoOrigamiFoldColumn a helptag
 


### PR DESCRIPTION
Nice to meet you, Ben! Thank you for writing this plugin.

In my .vimrc, I'm remapping every window command in normal mode. Most of them start with `<c-w>`, but there's at least one that doesnt: `z{nr}<cr>`. Vim documents it under the help: `:help zN<CR>`.

I don't want to get too deep into how I got the mapping to work, but I found that it was unexpectedly executing on every CursorHold autocmd event. A bit of careful debugging led me to the the `normal` commands in this plugin. If we add `!` to the end of each one, they won't ever trigger any mappings. 

I'm pretty sure the intent behind them was to always execute the native folding commands, so I can't think of any reason not to make sure they do that.